### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can see the DEMO in project [DEMO](https://github.com/WilliamZang/FastAnimat
 
 Minimum iOS Target: iOS 6.0+
 
-XCode version: 5.0+
+Xcode version: 5.0+
 
 ## Install
 The easiest way to install FastAnimation is using [CocoaPods](http://cocoadocs.org):


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
